### PR TITLE
fixes for factorio 0.17.35

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,3 +13,8 @@ Version: 0.2.1
 Date: 03. 03. 2019
   Changes :
     - Updating graphics and properties
+---------------------------------------------------------------------------------------------------
+Version: 0.2.2
+Date: 05. 03. 2019
+  Changes :
+    - Change references from power-armor-2 to power-armor-mk2 for factorio 0.17.35

--- a/info.json
+++ b/info.json
@@ -1,8 +1,8 @@
 {
   "name": "FactorioExtended-Plus-Equipment",
-  "version": "0.2.1",
-  "factorio_version": "0.17",
-  "date": "2019-03-03",
+  "version": "0.2.2",
+  "factorio_version": "0.17.35",
+  "date": "2019-05-03",
   "title": "FactorioExtended Plus-Equipment",
   "author": "jimmyjon711 (Original Author: Nath Gamer)",
   "homepage": "",

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -8,6 +8,7 @@ personal-roboport-mk3-equipment=Personal Roboport Mk3
 [item-description]
 
 [technology-name]
+power-armor-mk3=Power Armor Mk3
 
 [technology-description]
 

--- a/prototypes/technology/technology-equipment.lua
+++ b/prototypes/technology/technology-equipment.lua
@@ -2,10 +2,10 @@ data:extend(
 {
   {
     type = "technology",
-    name = "power-armor-3",
+    name = "power-armor-mk3",
     icon = "__base__/graphics/technology/power-armor-mk2.png",
     icon_size = 128,
-    prerequisites = {"titanium-processing", "rocket-silo", "power-armor-2"},
+    prerequisites = {"titanium-processing", "rocket-silo", "power-armor-mk2"},
     effects =
     {
       {


### PR DESCRIPTION
Changed power-armor-2 references to power-armor-mk2, and changed power-armor-3 to power-armor-mk3 to be consistent with the new name.

I'm not sure how to handle migration (I've never written a mod :) ) so this may break cases where someone has already researched power armor mk3... in my game I only had mk2 researched, and the changes worked there.